### PR TITLE
Exposing registering observer factory to make CFP more Spring friendly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmos-changefeedprocessor</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
     <name>Azure Cosmos ChangeFeed Processor</name>
     <description>Change feed processor library for Azure Cosmos SQL API</description>
     <url>https://github.com/Azure/azure-documentdb-changefeedprocessor-java</url>

--- a/src/main/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHost.java
+++ b/src/main/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHost.java
@@ -111,18 +111,10 @@ public class ChangeFeedEventHost implements IPartitionObserver<DocumentServiceLe
         return result;
     }
 
-    /**
-     * This code used to be async
-     *
-     * @param type the type
-     */
-    public void registerObserver(Class type) throws Exception
-    {
-        logger.info(String.format("Registering Observer of type %s", type));
-        ChangeFeedObserverFactory factory = new ChangeFeedObserverFactory(type);
-
-        registerObserverFactory(factory);
-
+    public void registerObserverFactory(IChangeFeedObserverFactory factory) {
+        logger.info(String.format("Registering Observer of type %s", factory.getClass()));
+        this.observerFactory = factory;
+        
         this.executorService.execute(()->{
             try {
                 start();
@@ -130,10 +122,6 @@ public class ChangeFeedEventHost implements IPartitionObserver<DocumentServiceLe
                 e.printStackTrace();
             }
         });
-    }
-
-    private void registerObserverFactory(ChangeFeedObserverFactory factory) {
-        this.observerFactory = factory;
     }
 
     private void start() throws Exception{

--- a/src/main/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHost.java
+++ b/src/main/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHost.java
@@ -125,7 +125,7 @@ public class ChangeFeedEventHost implements IPartitionObserver<DocumentServiceLe
     }
 
     public void registerObserverFactory(IChangeFeedObserverFactory factory) {
-        logger.info(String.format("Registering Observer of type %s", factory.getClass()));
+        logger.info(String.format("Registering Observer Factory of type %s", factory.getClass()));
         this.observerFactory = factory;
         
         this.executorService.execute(()->{

--- a/src/main/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHost.java
+++ b/src/main/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHost.java
@@ -111,6 +111,24 @@ public class ChangeFeedEventHost implements IPartitionObserver<DocumentServiceLe
         return result;
     }
 
+    /**
+     * This code used to be async
+     *
+     * @param type the type
+     */
+    public void registerObserver(Class type) throws Exception
+    {
+        logger.info(String.format("Registering Observer of type %s", type));
+        
+        this.executorService.execute(()->{
+            try {
+                start();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
     public void registerObserverFactory(IChangeFeedObserverFactory factory) {
         logger.info(String.format("Registering Observer of type %s", factory.getClass()));
         this.observerFactory = factory;

--- a/src/main/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHost.java
+++ b/src/main/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHost.java
@@ -119,6 +119,9 @@ public class ChangeFeedEventHost implements IPartitionObserver<DocumentServiceLe
     public void registerObserver(Class type) throws Exception
     {
         logger.info(String.format("Registering Observer of type %s", type));
+        ChangeFeedObserverFactory factory = new ChangeFeedObserverFactory(type);    
+
+        registerObserverFactory(factory);
         
         this.executorService.execute(()->{
             try {

--- a/src/main/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHost.java
+++ b/src/main/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHost.java
@@ -122,14 +122,6 @@ public class ChangeFeedEventHost implements IPartitionObserver<DocumentServiceLe
         ChangeFeedObserverFactory factory = new ChangeFeedObserverFactory(type);    
 
         registerObserverFactory(factory);
-        
-        this.executorService.execute(()->{
-            try {
-                start();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        });
     }
 
     public void registerObserverFactory(IChangeFeedObserverFactory factory) {

--- a/src/main/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHost.java
+++ b/src/main/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHost.java
@@ -155,6 +155,7 @@ public class ChangeFeedEventHost implements IPartitionObserver<DocumentServiceLe
         this.leasePrefix = String.format("%s%s_%s_%s", optionsPrefix, this.collectionLocation.getUri().getHost(), documentServices.getDatabaseID(), documentServices.getCollectionID());
 
         this.leaseManager = new DocumentServiceLeaseManager(
+                this.hostName,
                 this.auxCollectionLocation,
                 this.leasePrefix,
                 this.options.getLeaseExpirationInterval(),

--- a/src/main/com/microsoft/azure/documentdb/changefeedprocessor/internal/documentleasestore/DocumentServiceLeaseManager.java
+++ b/src/main/com/microsoft/azure/documentdb/changefeedprocessor/internal/documentleasestore/DocumentServiceLeaseManager.java
@@ -44,6 +44,7 @@ public class DocumentServiceLeaseManager implements ILeaseManager<DocumentServic
     private final static String CONTAINER_NAME_SUFFIX = "info";
     private final static int RETRY_COUNT_ON_CONFLICT = 5;
     private String containerNamePrefix;
+    private String hostName;
     private DocumentCollectionInfo leaseStoreCollectionInfo;
     private Duration leaseIntervalAllowance = Duration.ofMillis(25);
     private Duration leaseInterval;
@@ -60,7 +61,8 @@ public class DocumentServiceLeaseManager implements ILeaseManager<DocumentServic
         DocumentServiceLease run(DocumentServiceLease serverLease);
     }
 
-    public DocumentServiceLeaseManager(DocumentCollectionInfo leaseStoreCollectionInfo, String storeNamePrefix, Duration leaseInterval, Duration renewInterval, DocumentServices documentServices) {
+    public DocumentServiceLeaseManager(String hostName, DocumentCollectionInfo leaseStoreCollectionInfo, String storeNamePrefix, Duration leaseInterval, Duration renewInterval, DocumentServices documentServices) {
+        this.hostName = hostName;
         this.leaseStoreCollectionInfo = leaseStoreCollectionInfo;
         this.containerNamePrefix = storeNamePrefix;
         this.leaseInterval = leaseInterval;
@@ -185,6 +187,7 @@ public class DocumentServiceLeaseManager implements ILeaseManager<DocumentServic
 
                 if (tryGetLease(leaseDocId) == null) {
                     DocumentServiceLease documentServiceLease = new DocumentServiceLease();
+                    documentServiceLease.setOwner(hostName);
                     documentServiceLease.setId(leaseDocId);
                     documentServiceLease.setPartitionId(partitionId);
                     documentServiceLease.setContinuationToken(continuationToken);

--- a/src/test/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHostTest.java
+++ b/src/test/com/microsoft/azure/documentdb/changefeedprocessor/ChangeFeedEventHostTest.java
@@ -111,8 +111,9 @@ public class ChangeFeedEventHostTest {
         ChangeFeedEventHost host = new ChangeFeedEventHost("hostname", docInfo, docAux, options, hostOptions );
         Assert.assertNotNull(host);
 
+        IChangeFeedObserverFactory factory = new ChangeFeedObserverFactory(TestChangeFeedObserver.class);
         try {
-            host.registerObserver(TestChangeFeedObserver.class);
+            host.registerObserverFactory(factory);
 
             while(!host.getExecutorService().isTerminated() &&
                     !host.getExecutorService().isShutdown()){
@@ -121,7 +122,7 @@ public class ChangeFeedEventHostTest {
             }
         }
         catch(Exception e) {
-            Assert.fail("registerObserver exception " + e.getMessage());
+            Assert.fail("registerObserverfactory exception " + e.getMessage());
         }
     }
 }

--- a/src/test/com/microsoft/azure/documentdb/changefeedprocessor/LeaseTest.java
+++ b/src/test/com/microsoft/azure/documentdb/changefeedprocessor/LeaseTest.java
@@ -63,6 +63,7 @@ public class LeaseTest {
         DocumentServices documentServices = new DocumentServices(docAux);
 
         DocumentServiceLeaseManager leaseManager = new DocumentServiceLeaseManager(
+                "currentChangeFeedProcessorHost",
                 docAux,
                 "lease",
                 options.getLeaseExpirationInterval(),

--- a/src/test/com/microsoft/azure/documentdb/changefeedprocessor/Sample.java
+++ b/src/test/com/microsoft/azure/documentdb/changefeedprocessor/Sample.java
@@ -71,8 +71,9 @@ public class Sample {
 
         ChangeFeedEventHost host = new ChangeFeedEventHost("hostname", docInfo, docAux, options, hostOptions );
 
+        IChangeFeedObserverFactory factory = new ChangeFeedObserverFactory(TestChangeFeedObserver.class);
         try {
-            host.registerObserver(TestChangeFeedObserver.class);
+            host.registerObserverFactory(factory);
 
             while(!host.getExecutorService().isTerminated() &&
                     !host.getExecutorService().isShutdown()){

--- a/src/test/com/microsoft/azure/documentdb/changefeedprocessor/Sample.java
+++ b/src/test/com/microsoft/azure/documentdb/changefeedprocessor/Sample.java
@@ -73,7 +73,7 @@ public class Sample {
 
         IChangeFeedObserverFactory factory = new ChangeFeedObserverFactory(TestChangeFeedObserver.class);
         try {
-            host.registerObserverFactory(factory);
+            host.registerObserver(TestChangeFeedObserver.class);
 
             while(!host.getExecutorService().isTerminated() &&
                     !host.getExecutorService().isShutdown()){

--- a/src/test/com/microsoft/azure/documentdb/changefeedprocessor/SimpleTest.java
+++ b/src/test/com/microsoft/azure/documentdb/changefeedprocessor/SimpleTest.java
@@ -70,8 +70,10 @@ public class SimpleTest {
         ChangeFeedEventHost host = new ChangeFeedEventHost("hotsname", docInfo, docAux, options, new ChangeFeedHostOptions() );
         Assert.assertNotNull(host);
 
+        IChangeFeedObserverFactory factory = new ChangeFeedObserverFactory(TestChangeFeedObserver.class);
+        
         try {
-            host.registerObserver(TestChangeFeedObserver.class);
+            host.registerObserverFactory(factory);
 
             System.out.println("Press ENTER to finish");
             Scanner scanner = new Scanner(System.in);

--- a/src/test/com/microsoft/azure/documentdb/changefeedprocessor/SimpleTest.java
+++ b/src/test/com/microsoft/azure/documentdb/changefeedprocessor/SimpleTest.java
@@ -73,7 +73,7 @@ public class SimpleTest {
         IChangeFeedObserverFactory factory = new ChangeFeedObserverFactory(TestChangeFeedObserver.class);
         
         try {
-            host.registerObserverFactory(factory);
+            host.registerObserver(TestChangeFeedObserver.class);
 
             System.out.println("Press ENTER to finish");
             Scanner scanner = new Scanner(System.in);

--- a/src/test/com/microsoft/azure/documentdb/changefeedprocessor/internal/documentleasestore/DocumentServiceLeaseTestManagerTest.java
+++ b/src/test/com/microsoft/azure/documentdb/changefeedprocessor/internal/documentleasestore/DocumentServiceLeaseTestManagerTest.java
@@ -76,7 +76,7 @@ public class DocumentServiceLeaseTestManagerTest {
 
         DocumentServices documentServices = new DocumentServices(docInfo);
 
-        instance = new DocumentServiceLeaseManager(docInfo, "leases", DEFAULT_EXPIRATION_INTERVAL, DEFAULT_RENEW_INTERVAL,documentServices);
+        instance = new DocumentServiceLeaseManager("currentChangeFeedProcessorHost", docInfo, "leases", DEFAULT_EXPIRATION_INTERVAL, DEFAULT_RENEW_INTERVAL,documentServices);
         instance.initialize(true);
         
         // Clean up lease store before each test


### PR DESCRIPTION
Exposing registerObserverFactory as a replacement for registerObserver. This now facilitates using objects in the ChangeFeedObserverFactory as Singleton objects.